### PR TITLE
Allow configuration of auto reset, fetch size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val kafkaVersion = "2.1.+"
 val log4CatsVersion = "0.2.+"
 val pureConfigVersion = "0.10.+"
 val scalaTestVersion = "3.0.+"
+val squantsVersion = "1.3.+"
 
 def findJar(classPath: Seq[Attributed[File]], name: String): File =
   classPath.find(_.data.toString.containsSlice(name)).get.data
@@ -75,12 +76,14 @@ lazy val fable = (project in file("."))
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
       "com.github.pureconfig" %% "pureconfig" % pureConfigVersion,
+      "com.github.pureconfig" %% "pureconfig-squants" % pureConfigVersion,
       "com.heroku.sdk" % "env-keystore" % envKeyStoreVersion,
       "io.chrisdavenport" %% "log4cats-slf4j" % log4CatsVersion,
       "org.apache.kafka" % "kafka-clients" % kafkaVersion,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
       "org.typelevel" %% "cats-core" % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "org.typelevel" %% "squants" % squantsVersion,
       "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
     )
   )

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 kafka {
   consumer {
     auto-commit = false
+    auto-offset-reset = "earliest"
     batch-size = 1024
     client-id = "fable-test"
     group-id = "fable-test"


### PR DESCRIPTION
These are common values to configure for setting up consumers, and the
fetch size is required to be able to run in a throttled instance like
Heroku.